### PR TITLE
UPDATE: download url in start.sh script

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -129,7 +129,7 @@ else
     else
         curl --no-progress-meter -H "Accept-Encoding: identity" -H "Accept-Language: en" -L -A "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.$RandNum.212 Safari/537.36" -o /minecraft/downloads/version.html https://www.minecraft.net/en-us/download/server/bedrock
     fi
-    LatestURL=$(grep -o 'https://minecraft.azureedge.net/bin-linux/[^"]*' downloads/version.html)
+    LatestURL=$(grep -o 'https://www.minecraft.net/bedrockdedicatedserver/bin-linux/[^"]*' downloads/version.html)
 
     LatestFile=$(echo "$LatestURL" | sed 's#.*/##')
 
@@ -149,7 +149,7 @@ else
     elif [ ! -z "$PinFile" ]; then
         echo "Installing $PinFile"
         DownloadFile=$PinFile
-        DownloadURL="https://minecraft.azureedge.net/bin-linux/$PinFile"
+        DownloadURL="https://www.minecraft.net/bedrockdedicatedserver/bin-linux/$PinFile"
 
         # Download version of Minecraft Bedrock dedicated server if it's not already local
         if [ ! -f "downloads/$DownloadFile" ]; then


### PR DESCRIPTION
URL from where we download bedrock server has changed.
In this PR is updated address.

No logic change just URL update

Tests done:

Tested locally on pc and with new URL docker container had run a server
I checked that on created volume we have unpacked server data